### PR TITLE
Add regression model support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
-Hiro's test. Please delete this whenever you want
+# MLOps Group 8
+
+This repository contains an example MLOps pipeline used for coursework. The
+pipeline reads the dataset configured in `config.yaml`, applies preprocessing and
+trains a scikit-learn model. The configuration now supports a linear regression
+model which we use for the Spotify dataset.
+
+## Running the pipeline
+
+```bash
+python -m src.main --config config.yaml --stage all
+```
+
+## Running tests
+
+```bash
+pytest -q
+```

--- a/config.yaml
+++ b/config.yaml
@@ -21,7 +21,7 @@ data_split:
   random_state: 42
 
 model:
-  active: decision_tree  # Options: decision_tree, logistic_regression, random_forest
+  active: linear_regression  # Options: decision_tree, logistic_regression, random_forest, linear_regression
 
   decision_tree:
     save_path: models/decision_tree.pkl
@@ -43,6 +43,10 @@ model:
       n_estimators: 100
       max_depth: 5
       random_state: 42
+
+  linear_regression:
+    save_path: models/linear_regression.pkl
+    params: {}
 
 raw_features:  
   - rx_ds
@@ -96,13 +100,9 @@ features:
 target: OD
 
 metrics:
-  - Accuracy
-  - Precision (PPV)
-  - Recall (Sensitivity)
-  - Specificity
-  - F1 Score
-  - Negative Predictive Value (NPV)
-  - ROC AUC
+  - MSE
+  - MAE
+  - R2
 
 preprocessing:
   rename_columns:

--- a/tests/test_evaluator_regression.py
+++ b/tests/test_evaluator_regression.py
@@ -1,0 +1,13 @@
+import numpy as np
+from sklearn.linear_model import LinearRegression
+from evaluation import evaluator
+
+
+def test_evaluate_regression_basic(tmp_path):
+    X = np.arange(10).reshape(-1, 1)
+    y = np.arange(10) * 2.0
+    model = LinearRegression().fit(X, y)
+    config = {"metrics": ["mse", "mae", "r2"]}
+    metrics = evaluator.evaluate_regression(model, X, y, config, save_path=tmp_path / "metrics.json")
+    assert set(metrics.keys()) == {"MSE", "MAE", "R2"}
+    assert (tmp_path / "metrics.json").is_file()


### PR DESCRIPTION
## Summary
- add linear regression to model registry
- handle regression metrics (MSE, MAE, R2)
- update config defaults for linear regression
- document running pipeline in README
- test evaluator for regression

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*